### PR TITLE
Updated link to sample app

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -1,5 +1,5 @@
 This project is a repository for the lessons and tutorials over at http://www.learnopengles.com/
 
-The compiled app can be downloaded from the Android market at https://market.android.com/details?id=com.learnopengles.android
+The compiled app can be downloaded from the Android market at https://play.google.com/store/apps/details?id=com.learnopengles.android
 
 The WebGL tutorials can be viewed at http://www.learnopengles.com/

--- a/README.TXT
+++ b/README.TXT
@@ -1,5 +1,5 @@
 This project is a repository for the lessons and tutorials over at http://www.learnopengles.com/
 
-The compiled app can be downloaded from the Android market at https://play.google.com/store/apps/details?id=com.learnopengles.android
+The compiled app can be downloaded from the Google Play Store (originally the Android market) at https://play.google.com/store/apps/details?id=com.learnopengles.android
 
 The WebGL tutorials can be viewed at http://www.learnopengles.com/


### PR DESCRIPTION
Updated link and description to sample app. Google renamed Android market to Google Play Store few years ago and this small changes put used naming in sync with Google. 
