### PR TITLE
Checking for texture loading error early.

### DIFF
--- a/android/AndroidOpenGLESLessons/app/src/main/java/com/learnopengles/android/common/TextureHelper.java
+++ b/android/AndroidOpenGLESLessons/app/src/main/java/com/learnopengles/android/common/TextureHelper.java
@@ -13,34 +13,31 @@ public class TextureHelper
 		final int[] textureHandle = new int[1];
 		
 		GLES20.glGenTextures(1, textureHandle, 0);
-		
-		if (textureHandle[0] != 0)
-		{
-			final BitmapFactory.Options options = new BitmapFactory.Options();
-			options.inScaled = false;	// No pre-scaling
 
-			// Read in the resource
-			final Bitmap bitmap = BitmapFactory.decodeResource(context.getResources(), resourceId, options);
-						
-			// Bind to the texture in OpenGL
-			GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textureHandle[0]);
-			
-			// Set filtering
-			GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_NEAREST);
-			GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_NEAREST);
-			
-			// Load the bitmap into the bound texture.
-			GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, bitmap, 0);
-			
-			// Recycle the bitmap, since its data has been loaded into OpenGL.
-			bitmap.recycle();						
-		}
-		
 		if (textureHandle[0] == 0)
 		{
-			throw new RuntimeException("Error loading texture.");
+			throw new RuntimeException("Error generating texture name.");
 		}
-		
+
+		final BitmapFactory.Options options = new BitmapFactory.Options();
+		options.inScaled = false;	// No pre-scaling
+
+		// Read in the resource
+		final Bitmap bitmap = BitmapFactory.decodeResource(context.getResources(), resourceId, options);
+
+		// Bind to the texture in OpenGL
+		GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textureHandle[0]);
+
+		// Set filtering
+		GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_NEAREST);
+		GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_NEAREST);
+
+		// Load the bitmap into the bound texture.
+		GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, bitmap, 0);
+
+		// Recycle the bitmap, since its data has been loaded into OpenGL.
+		bitmap.recycle();
+
 		return textureHandle[0];
 	}
 }


### PR DESCRIPTION
I have moved the texture name generation check to be earlier in code, also made error wording more precise since we're generating a texture name, not loading the texture (yet): https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glGenTextures.xml